### PR TITLE
Feat/#27 Web 7주차 미션3 - 회원가입 (API 토큰)

### DIFF
--- a/Web 7주차/components/MainPage/BannerComponent.jsx
+++ b/Web 7주차/components/MainPage/BannerComponent.jsx
@@ -8,24 +8,45 @@ function BannerComponent() {
 
     useEffect(() => {
         const token = localStorage.getItem('token');
-        if (token) {
-            axios.get('http://localhost:8080/auth/me', {
-                headers: {
-                    Authorization: `Bearer ${token}`
-                }
-            })
-            .then(response => {
-                if (response.status === 200) {
-                    setUserName(response.data.name);
-                } else {
-                    console.error('유저 정보 가져오기 실패:', response.status);
-                }
-            })
-            .catch(error => {
-                console.error('유저 정보 가져오기 오류:', error);
-            })
-        }
+        
+        const fetchUserData = () => {
+            if (token) {
+                axios.get('http://localhost:8080/auth/me', {
+                    headers: {
+                        Authorization: `Bearer ${token}`
+                    }
+                })
+                .then(response => {
+                    if (response.status === 200) {
+                        setUserName(response.data.name);
+                    } else {
+                        console.error('유저 정보 가져오기 실패:', response.status);
+                    }
+                })
+                .catch(error => {
+                    console.error('유저 정보 가져오기 오류:', error);
+                });
+            } else {
+                // 토큰이 없으면 name을 비워줌
+                setUserName('');
+            }
+        };
+    
+        // 유저 데이터를 최초로 가져옴
+        fetchUserData();
+        // localStorage 변경을 감지하는 이벤트 리스너 추가
+        const handleStorageChange = (event) => {
+            if (event.key === 'token') {
+                fetchUserData();
+            }
+        };
+        window.addEventListener('storage', handleStorageChange);
+        // 컴포넌트가 언마운트될 때 이벤트 리스너 제거
+        return () => {
+            window.removeEventListener('storage', handleStorageChange);
+        };
     }, []);
+    
 
     return(
         <WelcomeContainer>

--- a/Web 7주차/components/MainPage/BannerComponent.jsx
+++ b/Web 7주차/components/MainPage/BannerComponent.jsx
@@ -1,8 +1,36 @@
 import styled from 'styled-components';
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
 
 function BannerComponent() {
+    const [name, setUserName] = useState('');
+    const [loading, setLoading] = useState(false);
+
+    useEffect(() => {
+        const token = localStorage.getItem('token');
+        if (token) {
+            axios.get('http://localhost:8080/auth/me', {
+                headers: {
+                    Authorization: `Bearer ${token}`
+                }
+            })
+            .then(response => {
+                if (response.status === 200) {
+                    setUserName(response.data.name);
+                } else {
+                    console.error('유저 정보 가져오기 실패:', response.status);
+                }
+            })
+            .catch(error => {
+                console.error('유저 정보 가져오기 오류:', error);
+            })
+        }
+    }, []);
+
     return(
-        <WelcomeContainer>Chacco의 Movie에 오신 걸 환영합니다 🥳</WelcomeContainer>
+        <WelcomeContainer>
+            {name ? `${name}님, Chacco의 Movie에 오신 걸 환영합니다 🥳` : 'Chacco의 Movie에 오신 걸 환영합니다 🥳'}
+        </WelcomeContainer>
     );
 }
 

--- a/Web 7주차/components/NavbarComponent.jsx
+++ b/Web 7주차/components/NavbarComponent.jsx
@@ -1,7 +1,8 @@
 import styled from 'styled-components';
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
+import axios from 'axios';
 
 // Styled components
 const Navbar = styled.div`
@@ -58,7 +59,40 @@ function NavbarComponent() {
     const [isLoggedIn, setIsLoggedIn] = useState(false);
     const [activeMenu, setActiveMenu] = useState(null);
 
+    useEffect(() => {
+        const token = localStorage.getItem('token');
+        const fetchUserData = () => {
+            if (token) {
+                axios.get('http://localhost:8080/auth/me', {
+                    headers: {
+                        Authorization: `Bearer ${token}`
+                    }
+                })
+                .then(response => {
+                    if (response.status === 200) {
+                        setIsLoggedIn(true);
+                        // setUserName(response.data.name);
+                    } else {
+                        console.error('유저 정보 가져오기 실패:', response.status);
+                        setIsLoggedIn(false);
+                    }
+                })
+                .catch(error => {
+                    setIsLoggedIn(false);
+                    console.error('유저 정보 가져오기 오류:', error);
+                });
+            } else {
+                setIsLoggedIn(false);
+            }
+        };
+        fetchUserData();
+    });
+
     const handleLoginClick = () => {
+        if (isLoggedIn) {
+            localStorage.removeItem('token');
+        }
+        fetchUserData();
         setIsLoggedIn(!isLoggedIn);
     };
 
@@ -70,8 +104,14 @@ function NavbarComponent() {
         <Navbar>
             <Link to="/popular-page"><MainText>UMC Chacco Movie</MainText></Link>
             <MenuBox>
-                <Link to="/login"><LoginText onClick={handleLoginClick}>{isLoggedIn ? '로그아웃' : '로그인'}</LoginText></Link>
-                <Link to="/signup"><MenuText isActive={activeMenu === 'signup'} onClick={() => handleMenuClick('signup')}>회원가입</MenuText></Link>
+                {isLoggedIn ? (
+                    <LoginText onClick={handleLoginClick}>로그아웃</LoginText>
+                ) : (
+                    <>
+                        <Link to="/login"><LoginText onClick={handleLoginClick}>로그인</LoginText></Link>
+                        <Link to="/signup"><MenuText isActive={activeMenu === 'signup'} onClick={() => handleMenuClick('signup')}>회원가입</MenuText></Link>
+                    </>
+                )}
                 <Link to="/popular-page"><MenuText isActive={activeMenu === 'popular'} onClick={() => handleMenuClick('popular')}>Popular</MenuText></Link>
                 <Link to="/now-playing-page"><MenuText isActive={activeMenu === 'now-playing'} onClick={() => handleMenuClick('now-playing')}>Now Playing</MenuText></Link>
                 <Link to="/top-rated-page"><MenuText isActive={activeMenu === 'top-rated'} onClick={() => handleMenuClick('top-rated')}>Top Rated</MenuText></Link>

--- a/Web 7주차/package-lock.json
+++ b/Web 7주차/package-lock.json
@@ -8,6 +8,7 @@
       "name": "-",
       "version": "0.0.0",
       "dependencies": {
+        "axios": "^1.7.2",
         "bootstrap": "^5.3.3",
         "react": "^18.2.0",
         "react-bootstrap": "^2.10.2",
@@ -1564,6 +1565,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -1577,6 +1583,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
+      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -1735,6 +1751,17 @@
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
       "dev": true
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1890,6 +1917,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/dequal": {
@@ -2520,6 +2555,25 @@
       "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
       "dev": true
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
@@ -2527,6 +2581,19 @@
       "dev": true,
       "dependencies": {
         "is-callable": "^1.1.3"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fs.realpath": {
@@ -3356,6 +3423,25 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -3691,6 +3777,11 @@
       "peerDependencies": {
         "react": ">=0.14.0"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/Web 7주차/package.json
+++ b/Web 7주차/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "axios": "^1.7.2",
     "bootstrap": "^5.3.3",
     "react": "^18.2.0",
     "react-bootstrap": "^2.10.2",

--- a/Web 7주차/pages/LoginPage.jsx
+++ b/Web 7주차/pages/LoginPage.jsx
@@ -7,6 +7,7 @@ function LoginPage() {
     const [id, setId] = useState('');
     const [password, setPassword] = useState('');
     const [isActive, setIsActive] = useState(false);
+    const [loading, setLoading] = useState(false);
 
     const [idError, setIdError] = useState('');
     const [passwordError, setPasswordError] = useState('');
@@ -33,11 +34,13 @@ function LoginPage() {
                 username: id,
                 password: password
             };
-    
+
+            setLoading(true);
             axios.post('http://localhost:8080/auth/login', requestBody)
                 .then(response => {
                     if (response.status === 200) {
-                        console.log(response.data);
+                        const token = response.data.token;
+                        localStorage.setItem('token', token);
                         navigate('/');
                     } else {
                         console.error('Sign-up failed with status:', response.status);
@@ -56,23 +59,28 @@ function LoginPage() {
                     } else {
                         console.error('Error', error.message);
                     }
+                })
+                .finally(() => {
+                    setLoading(false);
                 });
         }
-    }
+    };
 
     return(
-        <Container>
-            <LoginContainer>
-                <MainText>로그인 페이지</MainText>
-                <FormWrapper>
-                    <InputBox type="text" id="login-id" placeholder="아이디" value={id} onChange={(e) => setId(e.target.value)}/>
-                    {idError && <AlertText>{idError}</AlertText>}
-                    <InputBox type="password" id="login-pw" placeholder="비밀번호" value={password} onChange={(e) => setPassword(e.target.value)}/>
-                    {passwordError && <AlertText>{passwordError}</AlertText>}
-                    <SubmitButton isActive={isActive} disabled={!isActive} onClick={handleSubmit} style={{backgroundColor: isActive ? 'orange' : 'white'}}>로그인</SubmitButton>
-                </FormWrapper>
-            </LoginContainer>
-        </Container>
+        loading 
+            ? <Banner>로딩 중...</Banner>
+            : <Container>
+                <LoginContainer>
+                    <MainText>로그인 페이지</MainText>
+                    <FormWrapper>
+                        <InputBox type="text" id="login-id" placeholder="아이디" value={id} onChange={(e) => setId(e.target.value)}/>
+                        {idError && <AlertText>{idError}</AlertText>}
+                        <InputBox type="password" id="login-pw" placeholder="비밀번호" value={password} onChange={(e) => setPassword(e.target.value)}/>
+                        {passwordError && <AlertText>{passwordError}</AlertText>}
+                        <SubmitButton isActive={isActive} disabled={!isActive} onClick={handleSubmit} style={{backgroundColor: isActive ? 'orange' : 'white'}}>로그인</SubmitButton>
+                    </FormWrapper>
+                </LoginContainer>
+            </Container>
     );
 }
 
@@ -140,6 +148,11 @@ const SubmitButton = styled.button`
     border-radius: 23px;
     font-size: 17px;
     margin-top: 40px;
+`;
+
+const Banner = styled.div`
+    font-size: 20px;
+    font-color: white;
 `;
 
 

--- a/Web 7주차/pages/LoginPage.jsx
+++ b/Web 7주차/pages/LoginPage.jsx
@@ -1,12 +1,17 @@
 import styled from 'styled-components';
 import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import axios from 'axios';
 
 function LoginPage() {
     const [id, setId] = useState('');
     const [password, setPassword] = useState('');
+    const [isActive, setIsActive] = useState(false);
 
     const [idError, setIdError] = useState('');
     const [passwordError, setPasswordError] = useState('');
+
+    const navigate = useNavigate();
 
     useEffect(() => {
         setIdError(!id ? '아이디를 입력해주세요!' : '');
@@ -16,7 +21,44 @@ function LoginPage() {
             password.length > 12 ? '비밀번호는 최대 12자리 입니다.' :
             !/[A-Za-z]/.test(password) || !/\d/.test(password) || !/[!@#$%^&*]/.test(password) ? '비밀번호는 영어, 숫자, 특수문자를 포함해주세요.' : ''
         );
+        setIsActive(!idError && !passwordError);
     }, [id, password, idError, passwordError]);
+
+    const handleSubmit = () => {
+        if (isActive) {
+            console.log('아이디:',id);
+            console.log('비밀번호:', password);
+
+            const requestBody = {
+                username: id,
+                password: password
+            };
+    
+            axios.post('http://localhost:8080/auth/login', requestBody)
+                .then(response => {
+                    if (response.status === 200) {
+                        console.log(response.data);
+                        navigate('/');
+                    } else {
+                        console.error('Sign-up failed with status:', response.status);
+                    }
+                })
+                .catch(error => {
+                    if (error.response) {
+                        if (error.response.status === 401) {
+                            console.log(error.response.status, error.response.message);
+                            alert('로그인 실패! 아이디와 비밀번호가 일치하지 않습니다.');
+                        } else {
+                            alert(`서버 에러: ${error.response.status}`);
+                        }
+                    } else if (error.request) {
+                        console.error('No response was received');
+                    } else {
+                        console.error('Error', error.message);
+                    }
+                });
+        }
+    }
 
     return(
         <Container>
@@ -27,7 +69,7 @@ function LoginPage() {
                     {idError && <AlertText>{idError}</AlertText>}
                     <InputBox type="password" id="login-pw" placeholder="비밀번호" value={password} onChange={(e) => setPassword(e.target.value)}/>
                     {passwordError && <AlertText>{passwordError}</AlertText>}
-                    <SubmitButton>로그인</SubmitButton>
+                    <SubmitButton isActive={isActive} disabled={!isActive} onClick={handleSubmit} style={{backgroundColor: isActive ? 'orange' : 'white'}}>로그인</SubmitButton>
                 </FormWrapper>
             </LoginContainer>
         </Container>

--- a/Web 7주차/pages/SignUpPage.jsx
+++ b/Web 7주차/pages/SignUpPage.jsx
@@ -30,7 +30,6 @@ function SignUpPage() {
             console.log('나이:', age);
             console.log('비밀번호:', password);
             console.log('비밀번호 확인:', confirmPassword);
-            navigate('/login');
 
             const requestBody = {
                 name: name,
@@ -56,9 +55,11 @@ function SignUpPage() {
                     if (error.response) {
                         // 서버에서 응답한 에러 처리
                         if (error.response.status === 409) {
+                            console.log(error.response.status, error.response.message);
                             alert('이미 존재하는 아이디입니다.');
                         } else if (error.response.status === 400) {
                             alert('비밀번호가 일치하지 않습니다.');
+                            console.log(error.response.status, error.response.message);
                         } else {
                             // 기타 서버 에러 처리
                             alert(`서버 에러: ${error.response.status}`);

--- a/Web 7주차/pages/SignUpPage.jsx
+++ b/Web 7주차/pages/SignUpPage.jsx
@@ -2,6 +2,7 @@ import styled from 'styled-components';
 import React from 'react';
 import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
+import axios from 'axios';
 
 function SignUpPage() {
     const [name, setName] = useState('');
@@ -30,6 +31,46 @@ function SignUpPage() {
             console.log('비밀번호:', password);
             console.log('비밀번호 확인:', confirmPassword);
             navigate('/login');
+
+            const requestBody = {
+                name: name,
+                email: email,
+                age: age,
+                username: id,
+                password: password,
+                passwordCheck: confirmPassword,
+            };
+    
+            axios.post('http://localhost:8080/auth/signup', requestBody)
+                .then(response => {
+                    if (response.status === 201) {
+                        console.log(response.data);
+                        alert('회원가입이 완료됐어요!');
+                        navigate('/login');
+                    } else {
+                        console.error('Sign-up failed with status:', response.status);
+                    }
+                })
+                .catch(error => {
+                    // 에러 처리
+                    if (error.response) {
+                        // 서버에서 응답한 에러 처리
+                        if (error.response.status === 409) {
+                            alert('이미 존재하는 아이디입니다.');
+                        } else if (error.response.status === 400) {
+                            alert('비밀번호가 일치하지 않습니다.');
+                        } else {
+                            // 기타 서버 에러 처리
+                            alert(`서버 에러: ${error.response.status}`);
+                        }
+                    } else if (error.request) {
+                        // 요청이 이루어졌으나 응답을 받지 못한 경우
+                        console.error('No response was received');
+                    } else {
+                        // 요청 설정 중 발생한 에러 처리
+                        console.error('Error', error.message);
+                    }
+                });
         }
     };
 


### PR DESCRIPTION
### ✅ 관련 이슈
- close #27 
<br>

### 💚 완료한 내용 
**회원가입 요청**
[가상 백엔드 서버 API & 명세서](https://github.com/dydals3440/UMC-5th-SMUFLIX-BE/tree/main)
- [x]  `백엔드 서버를 본인 레포에 Fork 후, git clone` 하신 후 `npm install → npm start`
- [x]  우리가 만든 `validation 규격에 맞추어서 회원가입을 진행` (이때, 프론트에서도 validation에 맞지 않는다면 **formData가 전송되지 않게 처리**)
- [x]  서버를 실행한 후, 깃헙 README.md에 있는 API 명세서에 알맞게 데이터 요청을 해서 회원가입 진행 `**(경로: http://localhost:8080/auth/signup)**`
- [x]  정상적으로 회원가입이 되었다면, alert를 통해 회원가입이 정상적으로 처리되었다고 문구 보여주기
- [x]  사용자가 바로 로그인할 수 있도록 로그인 페이지로 이동시키기 `(경로 : /login)`
        
**로그인**
- [x]  본인이 `회원가입 요청한 아이디와 비밀번호를 활용해서 로그인을 진행`
- [x]  `로그인 요청 주소는 API 명세서를 통해 확인`
- [x]  정상적으로 로그인이 되었다면 `메인 페이지(경로: ‘/’)`로 이동
- [x]  로그인 시 받는 `토큰을 로컬스토리지에 저장`
- [x]  페이지를 이동하더라도 계속 로그인 상태가 유지되게 처리
- [x]  토큰을 따로 보관한 후, API 명세서를 확인해 보시면 토큰을 활용하여 로그인 한 유저의 이름을 받아온 후, 배너에 `name님 환영합니다.` 를 표기
- [x]  바로 유저 데이터를 못 받아오므로, 데이터를 받아올 때까지 중간에 `배너에 로딩 중…`이라는 배너가 보이도록 설정

**Navbar**
1. 로그인 된 상태일 때
- [x]  Navbar에 `로그아웃 버튼만 보이게 설정`
2. 로그아웃 된 상태일 때
- [x]  토큰 제거
- [x]  로그인 버튼을 상단 바에 보이게 하기 `(경로: /login)`
- [x]  회원가입 버튼을 상단 바에 보이게 하기`(경로: /signup)`
- [x]  배너는 `로그아웃 시 환영합니다 문구만 보이도록 설정`

<br>

### 📸 스크린샷

![스크린샷 2024-05-28 오전 12 21 37](https://github.com/SeyeonJang/UMC-6th-Web/assets/47477205/7b0fdcd5-7ffd-483d-901d-d9f9a72f1b64)

![image](https://github.com/SeyeonJang/UMC-6th-Web/assets/47477205/b2661448-22e4-4e20-a396-b33f4b6acf45)
