### PR TITLE
Feat/#32 Web 8주차 미션2 - SideBar 만들기

### DIFF
--- a/Web 8주차/components/NavbarComponent.jsx
+++ b/Web 8주차/components/NavbarComponent.jsx
@@ -190,13 +190,13 @@ function NavbarComponent() {
                 <Sidebar isOpen={sidebarOpen}>
                     <SideMenuText onClick={() => toggleSidebar()}>닫기</SideMenuText>
                     <>
-                        <Link to="/login"><SideLoginText onClick={handleLoginClick}>로그인</SideLoginText></Link>
-                        <Link to="/signup"><SideMenuText isActive={activeMenu === 'signup'} onClick={() => handleMenuClick('signup')}>회원가입</SideMenuText></Link>
+                        <Link to="/login"><SideLoginText onClick={() => {handleLoginClick, toggleSidebar()}}>로그인</SideLoginText></Link>
+                        <Link to="/signup"><SideMenuText isActive={activeMenu === 'signup'} onClick={() => {handleMenuClick('signup'), toggleSidebar()}}>회원가입</SideMenuText></Link>
                     </>
-                    <Link to="/popular-page"><SideMenuText isActive={activeMenu === 'popular'} onClick={() => handleMenuClick('popular')}>Popular</SideMenuText></Link>
-                    <Link to="/now-playing-page"><SideMenuText isActive={activeMenu === 'now-playing'} onClick={() => handleMenuClick('now-playing')}>Now Playing</SideMenuText></Link>
-                    <Link to="/top-rated-page"><SideMenuText isActive={activeMenu === 'top-rated'} onClick={() => handleMenuClick('top-rated')}>Top Rated</SideMenuText></Link>
-                    <Link to="/up-coming-page"><SideMenuText isActive={activeMenu === 'up-coming'} onClick={() => handleMenuClick('up-coming')}>Upcoming</SideMenuText></Link>
+                    <Link to="/popular-page"><SideMenuText isActive={activeMenu === 'popular'} onClick={() => {handleMenuClick('popular'), toggleSidebar()}}>Popular</SideMenuText></Link>
+                    <Link to="/now-playing-page"><SideMenuText isActive={activeMenu === 'now-playing'} onClick={() => {handleMenuClick('now-playing'), toggleSidebar()}}>Now Playing</SideMenuText></Link>
+                    <Link to="/top-rated-page"><SideMenuText isActive={activeMenu === 'top-rated'} onClick={() => {handleMenuClick('top-rated'), toggleSidebar()}}>Top Rated</SideMenuText></Link>
+                    <Link to="/up-coming-page"><SideMenuText isActive={activeMenu === 'up-coming'} onClick={() => {handleMenuClick('up-coming'), toggleSidebar()}}>Upcoming</SideMenuText></Link>
                 </Sidebar>
             )}
         </Navbar>

--- a/Web 8주차/components/NavbarComponent.jsx
+++ b/Web 8주차/components/NavbarComponent.jsx
@@ -62,48 +62,11 @@ const MenuText = styled.p`
     }
 `;
 
-const Sidebar = styled.div`
-    position: fixed;
-    top: 0;
-    right: ${({ isOpen }) => (isOpen ? "0" : "-250px")}; // isOpen 상태에 따라 위치 변경
-    width: 40%;
-    height: 100%;
-    background-color: #222222;
-    padding-top: 20px;
-    z-index: 100;
-    transition: right 0.3s ease-in-out;
-`;
-
-const SideMenuText = styled.p`
-    margin-top: 5px;
-    padding: 0px 10px;
-    color: ${({ isActive }) => (isActive ? 'orange' : 'white')};
-    font-size: 15px;
-    &:hover {
-        color: orange;
-        font-size: 15.5px;
-        font-weight: 600;
-    }
-`;
-
-const SideLoginText = styled.p`
-    margin-top: 5px;
-    padding: 0px 10px;
-    font-size: 15px;
-    color: orange;
-    &:hover {
-        color: orange;
-        font-size: 15.5px;
-        font-weight: 600;
-    }
-`;
-
 function NavbarComponent() {
     const [isLoggedIn, setIsLoggedIn] = useState(false);
     const [activeMenu, setActiveMenu] = useState(null);
     const [windowWidth, setWindowWidth] = useState(window.innerWidth);
     const [isMobileOrTablet, setIsMobileOrTablet] = useState(windowWidth < 1080);
-    const [sidebarOpen, setSidebarOpen] = useState(false);
 
     useEffect(() => {
         const handleResize = () => {
@@ -158,17 +121,13 @@ function NavbarComponent() {
         setActiveMenu(menu);
     }
 
-    const toggleSidebar = () => {
-        setSidebarOpen(!sidebarOpen); // 사이드바 토글 함수
-    };
-
     return (
         <Navbar>
             <Link to="/popular-page"><MainText>UMC Chacco Movie</MainText></Link>
             <MenuBox>
                 {isMobileOrTablet 
                 ? 
-                    <img src={MenuIcon} onClick={toggleSidebar} alt="loading" width="15px" height="15px" color='white'/>
+                    <img src={MenuIcon} alt="loading" width="15px" height="15px" color='white'/>
                 :
                 <>
                 {isLoggedIn ? (
@@ -186,19 +145,6 @@ function NavbarComponent() {
                 </>
                 }
             </MenuBox>
-            {isMobileOrTablet && (
-                <Sidebar isOpen={sidebarOpen}>
-                    <SideMenuText onClick={() => toggleSidebar()}>닫기</SideMenuText>
-                    <>
-                        <Link to="/login"><SideLoginText onClick={handleLoginClick}>로그인</SideLoginText></Link>
-                        <Link to="/signup"><SideMenuText isActive={activeMenu === 'signup'} onClick={() => handleMenuClick('signup')}>회원가입</SideMenuText></Link>
-                    </>
-                    <Link to="/popular-page"><SideMenuText isActive={activeMenu === 'popular'} onClick={() => handleMenuClick('popular')}>Popular</SideMenuText></Link>
-                    <Link to="/now-playing-page"><SideMenuText isActive={activeMenu === 'now-playing'} onClick={() => handleMenuClick('now-playing')}>Now Playing</SideMenuText></Link>
-                    <Link to="/top-rated-page"><SideMenuText isActive={activeMenu === 'top-rated'} onClick={() => handleMenuClick('top-rated')}>Top Rated</SideMenuText></Link>
-                    <Link to="/up-coming-page"><SideMenuText isActive={activeMenu === 'up-coming'} onClick={() => handleMenuClick('up-coming')}>Upcoming</SideMenuText></Link>
-                </Sidebar>
-            )}
         </Navbar>
     );
 }

--- a/Web 8주차/components/NavbarComponent.jsx
+++ b/Web 8주차/components/NavbarComponent.jsx
@@ -62,11 +62,48 @@ const MenuText = styled.p`
     }
 `;
 
+const Sidebar = styled.div`
+    position: fixed;
+    top: 0;
+    right: ${({ isOpen }) => (isOpen ? "0" : "-250px")}; // isOpen 상태에 따라 위치 변경
+    width: 40%;
+    height: 100%;
+    background-color: #222222;
+    padding-top: 20px;
+    z-index: 100;
+    transition: right 0.3s ease-in-out;
+`;
+
+const SideMenuText = styled.p`
+    margin-top: 5px;
+    padding: 0px 10px;
+    color: ${({ isActive }) => (isActive ? 'orange' : 'white')};
+    font-size: 15px;
+    &:hover {
+        color: orange;
+        font-size: 15.5px;
+        font-weight: 600;
+    }
+`;
+
+const SideLoginText = styled.p`
+    margin-top: 5px;
+    padding: 0px 10px;
+    font-size: 15px;
+    color: orange;
+    &:hover {
+        color: orange;
+        font-size: 15.5px;
+        font-weight: 600;
+    }
+`;
+
 function NavbarComponent() {
     const [isLoggedIn, setIsLoggedIn] = useState(false);
     const [activeMenu, setActiveMenu] = useState(null);
     const [windowWidth, setWindowWidth] = useState(window.innerWidth);
     const [isMobileOrTablet, setIsMobileOrTablet] = useState(windowWidth < 1080);
+    const [sidebarOpen, setSidebarOpen] = useState(false);
 
     useEffect(() => {
         const handleResize = () => {
@@ -121,13 +158,17 @@ function NavbarComponent() {
         setActiveMenu(menu);
     }
 
+    const toggleSidebar = () => {
+        setSidebarOpen(!sidebarOpen); // 사이드바 토글 함수
+    };
+
     return (
         <Navbar>
             <Link to="/popular-page"><MainText>UMC Chacco Movie</MainText></Link>
             <MenuBox>
                 {isMobileOrTablet 
                 ? 
-                    <img src={MenuIcon} alt="loading" width="15px" height="15px" color='white'/>
+                    <img src={MenuIcon} onClick={toggleSidebar} alt="loading" width="15px" height="15px" color='white'/>
                 :
                 <>
                 {isLoggedIn ? (
@@ -145,6 +186,19 @@ function NavbarComponent() {
                 </>
                 }
             </MenuBox>
+            {isMobileOrTablet && (
+                <Sidebar isOpen={sidebarOpen}>
+                    <SideMenuText onClick={() => toggleSidebar()}>닫기</SideMenuText>
+                    <>
+                        <Link to="/login"><SideLoginText onClick={handleLoginClick}>로그인</SideLoginText></Link>
+                        <Link to="/signup"><SideMenuText isActive={activeMenu === 'signup'} onClick={() => handleMenuClick('signup')}>회원가입</SideMenuText></Link>
+                    </>
+                    <Link to="/popular-page"><SideMenuText isActive={activeMenu === 'popular'} onClick={() => handleMenuClick('popular')}>Popular</SideMenuText></Link>
+                    <Link to="/now-playing-page"><SideMenuText isActive={activeMenu === 'now-playing'} onClick={() => handleMenuClick('now-playing')}>Now Playing</SideMenuText></Link>
+                    <Link to="/top-rated-page"><SideMenuText isActive={activeMenu === 'top-rated'} onClick={() => handleMenuClick('top-rated')}>Top Rated</SideMenuText></Link>
+                    <Link to="/up-coming-page"><SideMenuText isActive={activeMenu === 'up-coming'} onClick={() => handleMenuClick('up-coming')}>Upcoming</SideMenuText></Link>
+                </Sidebar>
+            )}
         </Navbar>
     );
 }


### PR DESCRIPTION
### ✅ 관련 이슈
- close #32 
<br>

### 💚 완료한 내용
**SideBar**
- [x]  태블릿&모바일 환경일 때 `메뉴 아이콘`이 나타나고, 아이콘을 누르면 `Sidebar가 나타나도록` 구현
- [x]  Sidebar 안의 내용은 `navbar와 같게`구현
- [x]  Sidebar 안의 메뉴를 클릭하면 페이지 이동과 동시에 `Sidebar가 닫혀야` 함
- [x]  Sidebar가 PC 환경일 때는 나타나지 않고 navbar가 나타나도록 설정
- [x]  가능하다면 Sidebar가 나타나고 사라질 때, 움직이는 애니메이션 구현
<br>

### 📸 스크린샷

https://github.com/SeyeonJang/UMC-6th-Web/assets/47477205/5aea5b87-65c7-4659-94ea-021fdc7f33f3

https://github.com/SeyeonJang/UMC-6th-Web/assets/47477205/f0dfd1c6-970f-445b-9aca-b18d903b7861